### PR TITLE
修改dplayer参数中含有参数问题

### DIFF
--- a/scripts/index.js
+++ b/scripts/index.js
@@ -3,12 +3,16 @@ const buildDatas = (args) => {
 
   if (args.length > 0) {
     args.forEach(item => {
-      let kv = item.split("=");
-      if (!kv[1]) {
-        datas += `data-${kv[0]} `
-      } else {
-        datas += `data-${kv[0]}='${kv[1]}' `;
+    
+      let index = item.indexOf("=")
+      if(index==-1){
+        datas += `data-${item} `
+      }else {
+        let key = item.substring(0,index)
+        let value = item.substring(index + 1,item.length)
+        datas += `data-${key}='${value}' `; 
       }
+   
     });
   }
 


### PR DESCRIPTION
在现有代码中。如果url带有参数，则会被分割，导致参数带不过去。视频播放失败。

比如下方就带了一个sign参数，但是sigin被分割了

```
{%  dplayer
    url='https://cloud.wenhaha.cn/api/v3/file/source/1003/%E7%9D%A1%E9%AD%94.%E7%AC%AC%E4%B8%80%E5%AD%A3.2022.EP04.HD1080P.X264.AAC.English.CHS-ENG.BDYS.mp4?sign=E9GmbPfrpBbvm_iyjnkQPH4GPZKIX8aI5SqQtGZJNyI%3D%3A0'
    pic="https://cloud.wenhaha.cn/api/v3/file/source/949/OIP.th.jpg?sign=dkLv26TfjGZ9T0Uj7OXItk5ctVjWs13WID2aGUPuRWQ%3D%3A0"
%}

```
本次更新解决了这个问题
