### PR TITLE
主题默认开启mathjax，公式与对应js加载由post属性单独配置

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -7,10 +7,6 @@ menu:
 # 主页banner图
 banner: https://qiniu.sukoshi.xyz/src/images/68686407_p0.jpg
 
-# LaTeX公式支持
-mathjax:
-    enable: false
-
 # 站点通知信息
 notice: flex-block主题部分重构，详情查看https://github.com/miiiku/flex-block
 
@@ -63,6 +59,11 @@ aplayer:
   loop: false
   mutex: true
   lrcType: 3
+
+# mathjax LaTeX公式支持
+#docs: http://docs.mathjax.org/en/latest/
+mathjax:
+    enable: true
 
 # 国内备案信息
 beian: 

--- a/layout/layout.ejs
+++ b/layout/layout.ejs
@@ -8,12 +8,7 @@
   <link rel="apple-touch-icon" href="/icons-192.png">
   <link rel="manifest" href="/manifest.json">
   
-  <!--latex数学显示公式支持-->
-  <% if (theme.mathjax.enable){ %>
-      
-    <script src="https://polyfill.io/v3/polyfill.min.js?features=es6"></script>
-    <script id="MathJax-script" async src="https://cdn.jsdelivr.net/npm/mathjax@3/es5/tex-mml-chtml.js"></script>
-  <% } %>
+
 
   <%- meta_generator() %>
 
@@ -53,6 +48,12 @@
 
   <% if (theme.favicon){ %>
     <%- favicon_tag(theme.favicon) %>
+  <% } %>
+
+  <% if (theme.mathjax.enable&&page.mathjax){ %> 
+    <!--mathjax latex数学公式显示支持-->
+  <script src="https://polyfill.io/v3/polyfill.min.js?features=es6"></script>
+  <script id="MathJax-script" async src="https://cdn.jsdelivr.net/npm/mathjax@3/es5/tex-mml-chtml.js"></script>
   <% } %>
 
   <% if (config.highlight.enable){ %>


### PR DESCRIPTION
浏览自己博客时候发现开启mathjax后每个帖子都得加载它的200多k的js，就算不需要用公式的页面也得加载，虽然能缓存但第一次访问就很慢，所以又按照主题的dplayer和aplayer配置方式修改了一下，主题配置默认开启mathjax，但是需要为需要公式的post（page其实也支持）的Front-matter添加Boolean型的`mathjax`属性，当这个属性为true时再引入这个js并启用latex公式支持的功能
这是我的一个post的例子
```
---
title: 
date: 
cover: 
toc: 
aplayer: 
dplayer:
mathjax: true
categories: 
tags:
---
```

（话说这么写的话是不是要改readme或者Demo里的Document了）