### PR TITLE
修复友链页面站点头像和描述不显示的问题

### DIFF
--- a/layout/_partial/page.ejs
+++ b/layout/_partial/page.ejs
@@ -14,13 +14,13 @@
           <% site.data.links.forEach(function(link) { %>
             <div class="link-item layout-padding">
               <a href="<%= link.link %>" title="<%= link.name %>" class="content-padding--primary soft-size--primary soft-style--box" target="_blank" rel="noopener noreferrer">
-                <% if (link.cover) { %>
-                <img src="<%= link.cover %>" alt="<%= link.name %>" class="soft-size--round soft-style--box">
+                <% if (link.avatar) { %>
+                <img src="<%= link.avatar %>" alt="<%= link.name %>" class="soft-size--round soft-style--box">
                 <% } %>
                 <div>
                   <h4 class="text-ellipsis"><%= link.name %></h4>
-                  <% if (link.describe) { %>
-                  <p class="text-ellipsis"><%= link.describe %></p>
+                  <% if (link.description) { %>
+                  <p class="text-ellipsis"><%= link.description %></p>
                   <% } %>
                 </div>
               </a>


### PR DESCRIPTION
有小伙伴发现了新版本友链站点头像和描述不显示的问题，原因是 ./layout/_partial/page.ejs 中仍然使用的是旧版的字段

旧版本中友链数据添加方式如下：
```yaml
- { "name" : "", "link" : "", "describe" : "", "cover" : "" }
```

新版本中按照miiiku大佬的在博客中的[教程描述](https://kyori.xyz/links)，友链数据添加方式理应如下：
```yaml
- { "name" : "", "link" : "", "description" : "", "avatar" : "" }
```

为契合描述，因此调整 page.ejs 以适应新版的字段。

Fixes #58 