### PR TITLE
新增文章页面支持显示“最后更新时间”

### DIFF
--- a/layout/_partial/article-list.ejs
+++ b/layout/_partial/article-list.ejs
@@ -20,8 +20,14 @@
             <% } %>
             <div class="card-text--row">
               <span>发布于</span>
-              <%- partial("../_widget/date", { class_name: null, post: post, date_format: null }) %>
+              <%- partial("../_widget/date", { class_name: 'article-date', post: post, date_format: null }) %>
             </div>
+            <% if ( date(post.updated, null) != date(post.date, null) ) { %>
+              <div class="card-text--row new-date">
+                <span>更新于</span>
+                <%- partial("../_widget/updated", { class_name: 'article-updated', post: post, date_format: null }) %>
+              </div>
+            <% } %>
             <%- partial("../_widget/category", { page: post, class_name: post.cover ? 'dark' : 'light' }) %>
             <%- partial("../_widget/tag", { page: post, class_name: post.cover ? 'dark' : 'light' }) %>
           </div>

--- a/layout/_partial/header.ejs
+++ b/layout/_partial/header.ejs
@@ -72,6 +72,10 @@
             <span>发布于</span>
             <%- partial("../_widget/date", { class_name: 'article-date', post: page, date_format: null }) %>
           </h2>
+          <h2 class="title-sub-wrap">
+            <span>最后更新于</span>
+            <%- partial("../_widget/updated", { class_name: 'article-updated', post: page, date_format: null }) %>
+          </h2>
           <%- partial("../_widget/category", { page: page, class_name: 'dark' }) %>
           <%- partial("../_widget/tag", { page: page, class_name: 'dark' }) %>
         </div>

--- a/layout/_partial/header.ejs
+++ b/layout/_partial/header.ejs
@@ -72,10 +72,12 @@
             <span>发布于</span>
             <%- partial("../_widget/date", { class_name: 'article-date', post: page, date_format: null }) %>
           </h2>
-          <h2 class="title-sub-wrap">
-            <span>最后更新于</span>
-            <%- partial("../_widget/updated", { class_name: 'article-updated', post: page, date_format: null }) %>
-          </h2>
+          <% if ( date(page.updated, null) != date(page.date, null) ) { %>
+            <h2 class="title-sub-wrap new-date">
+              <span>最后更新于</span>
+              <%- partial("../_widget/updated", { class_name: 'article-updated', post: page, date_format: null }) %>
+            </h2>
+          <% } %>
           <%- partial("../_widget/category", { page: page, class_name: 'dark' }) %>
           <%- partial("../_widget/tag", { page: page, class_name: 'dark' }) %>
         </div>

--- a/layout/_widget/updated.ejs
+++ b/layout/_widget/updated.ejs
@@ -1,0 +1,1 @@
+<time  class="<%= class_name %>" datetime="<%= date_xml(post.updated) %>" itemprop="dateUpdated"><%= date(post.updated, date_format) %></time>

--- a/source/css/_partial/card.styl
+++ b/source/css/_partial/card.styl
@@ -51,5 +51,11 @@
       font-size: var(--font-common-size);
       margin-top: 20px;
     }
+
+    // new date
+    .new-date {
+      font-size: var(--font-base-size)
+      margin-top: 0px;
+    }
   }
 }

--- a/source/css/_partial/header.styl
+++ b/source/css/_partial/header.styl
@@ -65,3 +65,9 @@
   margin-top: 18px
   font-size: var(--font-common-size)
 }
+
+// new date
+.new-date {
+  font-size: var(--font-base-size)
+  margin-top: 0px
+}


### PR DESCRIPTION
1. 文章详情页会显示“最后更新于 xxxx-xx-xx”
2. 文章卡片会显示“更新于 xxxx-xx-xx”
3. “更新时间”的字体大小比“发布时间”小2px
4. 当“更新时间”和“发布时间”为同一天时，不显示“最后更新时间”
5. 请在 ./<Hexo站点目录>/scaffolds/post.md 添加以下 front-matter 属性：updated: {{ date }} ，如果没有该属性，或该属性不填写， Hexo 会自动读取 Markdown 文件的“修改时间”作为该属性

预览效果：
- 文章卡片
![image](https://user-images.githubusercontent.com/37256067/209494747-19b1b218-7e96-4c7e-83e1-2f4f72bffd1f.png)
- 文章详情页
![image](https://user-images.githubusercontent.com/37256067/209494808-b1ee394e-04b7-49e2-99a1-3ba1d6794ccd.png)

请大佬看看以上预览效果如何。 @miiiku 
Fixes #62 