### PR TITLE
添加了一个画风非常不统一的简陋的复制代码按键

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -68,7 +68,11 @@ aplayer:
 # mathjax LaTeX公式支持
 #docs: http://docs.mathjax.org/en/latest/
 mathjax:
-    enable: true
+  enable: true
+
+polyfill:
+  enable: false
+
 
 # 国内备案信息
 beian: 

--- a/_config.yml
+++ b/_config.yml
@@ -70,6 +70,11 @@ aplayer:
 mathjax:
   enable: true
 
+# clipboard.js
+# docs: https://clipboardjs.com/
+copy_button:
+  enable: false
+
 # polyfill 提供老版浏览器对新语法的支持
 # website: https://polyfill.io/v3/ 
 polyfill:

--- a/_config.yml
+++ b/_config.yml
@@ -26,7 +26,7 @@ comments:
   # valine 评论
   # docs: https://valine.js.org
   # You can get your appid and appkey from https://leancloud.cn
-  # 这里appId和appKey一定一定要改成自己的，没有的话去https://leancloud.cn这个网站注册创建一个
+  # 这里appId和appKey一定一定要改成自己的，没有的话去 https://leancloud.cn 这个网站注册创建一个
   valine:
     appId: 
     appKey: 
@@ -66,10 +66,12 @@ aplayer:
   lrcType: 3
 
 # mathjax LaTeX公式支持
-#docs: http://docs.mathjax.org/en/latest/
+# docs: http://docs.mathjax.org/en/latest/
 mathjax:
   enable: true
 
+# polyfill 提供老版浏览器对新语法的支持
+# website: https://polyfill.io/v3/ 
 polyfill:
   enable: false
 

--- a/layout/_partial/footer-script.ejs
+++ b/layout/_partial/footer-script.ejs
@@ -8,6 +8,10 @@
 <%- partial('../plug-in/dplayer') %>
 <% } %>
 
+<!-- copy button  -->
+<%- partial('../plug-in/clipboard') %>
+
+
 <%# Gaug.es Analytics %>
 <% if (theme.gauges_analytics) { %>
   <!-- Gaug.es Analytics START -->

--- a/layout/layout.ejs
+++ b/layout/layout.ejs
@@ -58,7 +58,7 @@
     <script id="MathJax-script" async src="https://cdn.jsdelivr.net/npm/mathjax@3/es5/tex-mml-chtml.js"></script>
   <% } %>
 
-  <% if (config.highlight.enable){ %>
+  <% if (config.highlight.enable) { %>
     <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/typeface-source-code-pro@1.1.13/index.min.css">
     <link rel="stylesheet" href="https://cdn.jsdelivr.net/gh/highlightjs/cdn-release@11.7.0/build/styles/<%= config.highlight.theme || 'monokai' %>.min.css">
   <% } %>

--- a/layout/layout.ejs
+++ b/layout/layout.ejs
@@ -59,8 +59,8 @@
   <% } %>
 
   <% if (config.highlight.enable){ %>
-    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/typeface-source-code-pro@1.1.3/index.min.css">
-    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/highlightjs@9.16.2/styles/<%= config.highlight.theme || 'monokai' %>.css">
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/typeface-source-code-pro@1.1.13/index.min.css">
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/gh/highlightjs/cdn-release@11.7.0/build/styles/<%= config.highlight.theme || 'monokai' %>.min.css">
   <% } %>
 
   <%- css('css/style') %>

--- a/layout/layout.ejs
+++ b/layout/layout.ejs
@@ -7,9 +7,9 @@
   <meta name="theme-color" content="#3367D6"/>
   <link rel="apple-touch-icon" href="/icons-192.png">
   <link rel="manifest" href="/manifest.json">
+
+
   
-
-
   <%- meta_generator() %>
 
   <% if (config.description) { %>
@@ -50,10 +50,12 @@
     <%- favicon_tag(theme.favicon) %>
   <% } %>
 
-  <% if (theme.mathjax.enable&&page.mathjax){ %> 
-    <!--mathjax latex数学公式显示支持-->
-  <script src="https://polyfill.io/v3/polyfill.min.js?features=es6"></script>
-  <script id="MathJax-script" async src="https://cdn.jsdelivr.net/npm/mathjax@3/es5/tex-mml-chtml.js"></script>
+  <% if (theme.polyfill.enable) { %>
+    <script src="https://polyfill.io/v3/polyfill.min.js?features=es6"></script>
+  <% } %>
+  <!--mathjax latex数学公式显示支持-->
+  <% if (theme.mathjax.enable && page.mathjax) { %> 
+    <script id="MathJax-script" async src="https://cdn.jsdelivr.net/npm/mathjax@3/es5/tex-mml-chtml.js"></script>
   <% } %>
 
   <% if (config.highlight.enable){ %>

--- a/layout/plug-in/clipboard.ejs
+++ b/layout/plug-in/clipboard.ejs
@@ -1,0 +1,32 @@
+<% if (theme.copy_button.enable) { %>
+    <script src="
+    https://cdn.jsdelivr.net/npm/clipboard@2.0.11/dist/clipboard.min.js
+    "></script>
+    <script type="text/javascript">
+            
+        let copyButtonClass = 'copy-btn'
+        
+        //  instantiate clipboardjs 
+        new ClipboardJS('.'+copyButtonClass)
+
+        document.querySelectorAll('td.code').forEach((elem)=>{
+            let copyButton = document.createElement('button')
+            copyButton.setAttribute("class",copyButtonClass)
+            copyButton.innerText = 'copy'
+
+            // style
+            copyButton.style.padding = "4px 8px"
+            copyButton.style.marginTop = '6px'
+            
+            copyButton.onclick = ()=>{
+                copyButton.innerText = 'copied'
+                setInterval( ()=>{
+                    copyButton.innerText = 'copy'
+                },3000)
+            }
+            copyButton.setAttribute("data-clipboard-text",elem.innerText)
+            elem.appendChild(copyButton)
+})
+    </script>
+    <% } %>
+  

--- a/layout/plug-in/dplayer.ejs
+++ b/layout/plug-in/dplayer.ejs
@@ -1,7 +1,7 @@
 <% if (theme.dplayer.enable) { %>
 <!-- dplayer 视频 start -->
-<script type="text/javascript" src="https://unpkg.com/hls.js@1.0.1/dist/hls.js"></script>
-<script type="text/javascript" src="https://unpkg.com/dplayer@1.25.1/dist/DPlayer.min.js"></script>
+<script type="text/javascript" src="https://unpkg.com/hls.js@1.4.8/dist/hls.js"></script>
+<script type="text/javascript" src="https://unpkg.com/dplayer@1.27.1/dist/DPlayer.min.js"></script>
 <script type="text/javascript">
   const dplayer = document.querySelectorAll(".dplayer-box");
   dplayer && initDPlayer(dplayer);


### PR DESCRIPTION
效果
![image](https://github.com/miiiku/hexo-theme-flexblock/assets/53005337/c22b8b77-4602-4988-946c-bbdbf599f22f)
![image](https://github.com/miiiku/hexo-theme-flexblock/assets/53005337/86507619-7ac8-4dda-8b99-77f4a11c3700)
![image](https://github.com/miiiku/hexo-theme-flexblock/assets/53005337/9bb15e2b-02c0-45f2-878c-3d4c6b0a32e6)
~~它也不是固定在哪个角落的，所以看起来真的太丑了~~
由于本人前端开发和ui设计一类的并不熟悉，只对着clipboard.js的示例搓出来了一个原生button的实现，所以默认关闭此选项防止风格不统一。如有需要可以去主题的`_config.yml`中修改来开启，**需要将`config.highlight.enable`设为true**。

~~非常非常需要大佬来美化~~

## 其他小修改
- 删除mathjax在使用时对polyfill的默认依赖，当然也可以在配置中开启
- 更新了一些依赖的组件的版本

## 疑问
- 是否应该允许其他开发者更新文档？
相较于目前的文档，项目已经多出一些新功能，但由于文档并不位于本项目中，进行PR的开发者无法跟随新功能的实现和BUG的修复而跟进修改文档。所以或许我们需要一种解决方案能让其他开发者进行文档更新，比如迁移文档到本仓库中、使用仓库wiki或其他
方案。

- 是否应该为代码块添加横向滚动条？
在使用中发现，当单行代码过长可能会超出代码块显示范围，而横向滚动条在代码块中并不会显示，这样使用起来可能并不会很方便。