### PR TITLE
让主题支持通过 npm 方式安装

### DIFF
--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -1,0 +1,19 @@
+name: npm publish
+
+on:
+  release:
+    types: [created]
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-node@v3
+        with:
+          node-version: 12.x
+          registry-url: https://registry.npmjs.org/
+      - run: npm install
+      - run: npm publish
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/.prettierrc.cjs
+++ b/.prettierrc.cjs
@@ -1,0 +1,7 @@
+// 代码规范配置文件
+module.exports = {
+  // 不使用 Tab 缩进
+  useTabs: false,
+  // 缩进 2 个空格
+  tabWidth: 2,
+};

--- a/README.md
+++ b/README.md
@@ -1,14 +1,17 @@
+# hexo-theme-flexblock
 
-# flex-block
+![master version](https://img.shields.io/github/package-json/v/miiiku/hexo-theme-flexblock/master?label=master&color=bf00ff)
+![npm version](https://img.shields.io/npm/v/hexo-theme-flexblock?color=bc3433)
+![hexo version](https://img.shields.io/badge/hexo-5.0.0+-0e83cd)
+![license](https://img.shields.io/github/license/miiiku/hexo-theme-flexblock?color=1ab1ad)
 
-一个基于`Hexo`的主题
+一个卡片类拟态风格的Hexo主题
 
 ![flex-block--home](./screenshots/flex-block--home.jpeg)
 
 ![flex-block--post](./screenshots/flex-block--post.jpeg)
 
-### v2.0以发布，重构部分代码。如需要查看v1.0的代码请访问:[v1.0](https://github.com/miiiku/hexo-theme-flexblock/tree/v1.0)
-
+### v2.0已发布，重构部分代码。如需要查看v1.0的代码请访问:[v1.0](https://github.com/miiiku/hexo-theme-flexblock/tree/v1.0)
 
 ## Example Site
 
@@ -26,25 +29,34 @@ doc list: [docs](https://kyori.xyz/categories/doc/)
 
 - [插入图片，音频和视频](https://kyori.xyz/2021/07/081010.html)
 
+### 安装主题
 
-### Install
+#### 通过 GIT 安装
 
-#### 下载`flex-block`
+从 GitHub 下载主题并将其添加到你的 Hexo 项目目录的 `themes` 目录下
 
-从GitHub下载主题并将其添加到网站目录: themes
-
-进入你的网站目录并执行以下代码:
-
-```
-git clone https://github.com/miiiku/hexo-theme-flexblock.git ./themes/flex-block
+```shell
+# 通过 git clone 命令将主题下载到 theme 目录
+git clone https://github.com/miiiku/hexo-theme-flexblock.git ./themes/flexblock
 ```
 
-如果你不是`git`用户也可以从[https://github.com/miiiku/hexo-theme-flexblock/archive/refs/heads/master.zip](https://github.com/miiiku/hexo-theme-flexblock/archive/refs/heads/master.zip)下载压缩包解压到你的网站目录下的`theme`文件夹下并重命名`hexo-theme-flexblock-master`为`flex-block`。
+> 如果你不是 `git` 用户，也可以从[https://github.com/miiiku/hexo-theme-flexblock/archive/refs/heads/master.zip](https://github.com/miiiku/hexo-theme-flexblock/archive/refs/heads/master.zip)下载主题的压缩包，然后解压到你的 Hexo 项目目录的 `theme` 目录下，并重命名 `hexo-theme-flexblock-master` 为 `flexblock` 。
 
-#### 修改一些主题配置
+进入 `./themes/flexblock` 编辑 `_config.yml` 以配置你的站点信息
 
-进入`themes/flex-block`编辑`_config.yml`以配置你的站点信息
+#### 通过 NPM 安装
 
-#### 应用当前主题为`flex-block`
+> 此方法只支持 Hexo 5.0.0 以上版本
 
-编辑`_config.yml`文件找到**theme**并设置值为`flex-block`
+```shell
+# 通过 npm 将主题的 package 安装到你的 Hexo 项目中
+npm install hexo-theme-flexblock
+# # 如果使用 yarn，则执行以下命令
+# yarn add hexo-theme-flexblock
+```
+
+在你的 Hexo 项目目录下新建 `_config.flexblock.yml`，然后把 [主题配置文件的内容](https://github.com/miiiku/hexo-theme-flexblock/blob/master/_config.yml) 粘贴到文件里面，再配置你的站点信息
+
+### 应用主题
+
+编辑你的 Hexo 项目目录下的 `_config.yml` 文件，找到**theme**并设置值为 `flexblock`

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hexo-theme-flexblock",
-  "version": "2.12.0",
+  "version": "2.12.1",
   "description": "A Card UI Design and Neumorphism Design theme for Hexo",
   "license": "MIT",
   "main": "package.json",

--- a/package.json
+++ b/package.json
@@ -1,0 +1,51 @@
+{
+  "name": "hexo-theme-flexblock",
+  "version": "2.12.0",
+  "description": "A Card UI Design and Neumorphism Design theme for Hexo",
+  "license": "MIT",
+  "main": "package.json",
+  "scripts": {
+    "test": "echo \"Error: no test specified\" && exit 1"
+  },
+  "keywords": [
+    "hexo",
+    "theme",
+    "flexblock",
+    "card",
+    "neumorphism"
+  ],
+  "homepage": "https://kyori.xyz",
+  "repository": {
+    "type" : "git",
+    "url" : "https://github.com/miiiku/hexo-theme-flexblock.git"
+  },
+  "bugs": {
+    "url": "https://github.com/miiiku/hexo-theme-flexblock/issues"
+  },
+  "author": {
+      "name": "miiiku",
+      "email": "guanquanhong@163.com",
+      "url": "https://github.com/miiiku"
+  },
+  "contributors": [
+    {
+      "name": "seeleclover",
+      "email": "seeleclover@outlook.com",
+      "url": "https://github.com/seeleclover"
+    },
+    {
+      "name": "dangjinghao",
+      "email": "dangjinghaoemail@163.com",
+      "url": "https://github.com/dangjinghao"
+    },
+    {
+      "name": "LunaroakF",
+      "email": "smallkay063@foxmail.com",
+      "url": "https://github.com/LunaroakF"
+    }
+  ],
+  "dependencies": {
+    "hexo-renderer-ejs": "^2.0.0",
+    "hexo-renderer-stylus": "^2.1.0"
+  }
+}


### PR DESCRIPTION
Fixes #73 

PR 合并后，需要在 Github 项目的 Settings - Secrets and variables - Actions 页面添加 Repository secrets，  
内容为 `NPM_TOKEN: xxxxxxxxxx`，密钥内容已私发到 QQ。

![image](https://github.com/miiiku/hexo-theme-flexblock/assets/37256067/1aaa13fa-38ff-412e-929c-6c8cef4e5ad1)
