### PR TITLE
特定情况下的滚动到顶部修复以及添加jsdelivr镜像站支持

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -75,6 +75,9 @@ mathjax:
 polyfill:
   enable: false
 
+# jsdelivr镜像域名
+# e.g. cdn.example.com
+jsdelivr_mirror: 
 
 # 国内备案信息
 beian: 

--- a/layout/layout.ejs
+++ b/layout/layout.ejs
@@ -53,23 +53,23 @@
     <script src="https://polyfill.io/v3/polyfill.min.js?features=es6"></script>
   <% } %>
   <% if (theme.mathjax.enable && page.mathjax) { %> 
-    <script id="MathJax-script" async src="https://cdn.jsdelivr.net/npm/mathjax@3/es5/tex-mml-chtml.js"></script>
+    <script id="MathJax-script" async src="https://<%= theme.jsdelivr_mirror || 'cdn.jsdelivr.net' %>/npm/mathjax@3/es5/tex-mml-chtml.js"></script>
   <% } %>
 
   <% if (config.highlight.enable) { %>
-    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/typeface-source-code-pro@1.1.13/index.min.css">
-    <link rel="stylesheet" href="https://cdn.jsdelivr.net/gh/highlightjs/cdn-release@11.7.0/build/styles/<%= config.highlight.theme || 'monokai' %>.min.css">
+    <link rel="stylesheet" href="https://<%= theme.jsdelivr_mirror || 'cdn.jsdelivr.net' %>/npm/typeface-source-code-pro@1.1.13/index.min.css">
+    <link rel="stylesheet" href="https://<%= theme.jsdelivr_mirror || 'cdn.jsdelivr.net' %>/gh/highlightjs/cdn-release@11.7.0/build/styles/<%= config.highlight.theme || 'monokai' %>.min.css">
   <% } %>
 
   <% if (config.prismjs.enable) { %>
     <% if (config.prismjs.preprocess) { %>
-      <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/prismjs@1.29.0/plugins/line-numbers/prism-line-numbers.min.css">
+      <link rel="stylesheet" href="https://<%= theme.jsdelivr_mirror || 'cdn.jsdelivr.net' %>/npm/prismjs@1.29.0/plugins/line-numbers/prism-line-numbers.min.css">
     <% } else { %>
-      <script src="https://cdn.jsdelivr.net/npm/prismjs@1.29.0/prism.min.js"></script>
-      <script src="https://cdn.jsdelivr.net/npm/prismjs@1.29.0/plugins/line-numbers/prism-line-numbers.min.js"></script>
-      <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/prismjs@1.29.0/plugins/line-numbers/prism-line-numbers.min.css">
+      <script src="https://<%= theme.jsdelivr_mirror || 'cdn.jsdelivr.net' %>/npm/prismjs@1.29.0/prism.min.js"></script>
+      <script src="https://<%= theme.jsdelivr_mirror || 'cdn.jsdelivr.net' %>/npm/prismjs@1.29.0/plugins/line-numbers/prism-line-numbers.min.js"></script>
+      <link rel="stylesheet" href="https://<%= theme.jsdelivr_mirror || 'cdn.jsdelivr.net' %>/npm/prismjs@1.29.0/plugins/line-numbers/prism-line-numbers.min.css">
     <% } %>
-    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/prismjs@1.29.0/themes/prism-tomorrow.min.css">
+    <link rel="stylesheet" href="https://<%= theme.jsdelivr_mirror || 'cdn.jsdelivr.net' %>/npm/prismjs@1.29.0/themes/prism-tomorrow.min.css">
   <% } %>
 
   <%- css('css/style') %>

--- a/layout/plug-in/clipboard.ejs
+++ b/layout/plug-in/clipboard.ejs
@@ -1,4 +1,4 @@
-<script src="https://cdn.jsdelivr.net/npm/clipboard@2.0.11/dist/clipboard.min.js"></script>
+<script src="https://<%= theme.jsdelivr_mirror || 'cdn.jsdelivr.net' %>/npm/clipboard@2.0.11/dist/clipboard.min.js"></script>
 
 <!-- https://clipboardjs.com/ -->
 

--- a/source/js/script.js
+++ b/source/js/script.js
@@ -4,13 +4,34 @@ window.addEventListener("DOMContentLoaded", function() {
   const navList         = document.querySelector(".navbar-list");
   const backToTopFixed  = document.querySelector(".back-to-top-fixed");
   let lastTop           = 0;
+  let lastRefreshTime   = 0;
+  let frameCount        = 0;
+  let refreshRate       = 0;
   let theme             = window.localStorage.getItem('theme') || '';
 
   theme && html.classList.add(theme)
 
+
+  /**
+   * 初始化刷新率估计
+   */
+  const estimateRefreshRate = () => {
+      const currentTime = performance.now();
+      if (currentTime - lastRefreshTime >= 1000) { // fps
+          refreshRate = frameCount;
+          frameCount = 0;
+          lastRefreshTime = currentTime;
+      } else {
+          frameCount++;
+      }
+      requestAnimationFrame(estimateRefreshRate);
+  }
+  
+  estimateRefreshRate();
+
   const goScrollTop = () => {
     let currentTop = getScrollTop()
-    let speed = Math.floor(-currentTop / 10)
+    let speed = Math.floor(-currentTop / (refreshRate / 6))
     if (currentTop > lastTop + 0.5 || currentTop < lastTop - 0.5 ) {
       // interrupt the animation
       return lastTop = 0

--- a/source/js/script.js
+++ b/source/js/script.js
@@ -11,7 +11,8 @@ window.addEventListener("DOMContentLoaded", function() {
   const goScrollTop = () => {
     let currentTop = getScrollTop()
     let speed = Math.floor(-currentTop / 10)
-    if (currentTop > lastTop) {
+    if (currentTop > lastTop + 0.5 || currentTop < lastTop - 0.5 ) {
+      // interrupt the animation
       return lastTop = 0
     }
     let distance = currentTop + speed;


### PR DESCRIPTION
1. 在我的环境下，可能会出现给`scrollTop`赋值后立刻再次读取，两者结果存在极小的不一致的情况，可能是和浏览器优化滚动或者屏幕刷新率或者神奇的浮点数存储有关。
![c22bea11eefd4cd1d5717f1ee09216dd](https://github.com/miiiku/hexo-theme-flexblock/assets/53005337/4f223f5d-5db8-4238-b350-ab3df6c49c21)
- 这个问题导致：在特定环境下，回到顶部的按键在滚动到特定位置不能正常使用。在经过几次距离迭代计算后会因为这个情况被判定为动画被中断从而停止迭代和向上滚动。
- 通过改用更加宽泛的停止条件来避免此问题。
2. 将滚动速率和屏幕刷新率关联
- 由于`window.requestAnimationFrame`具有**回调函数执行次数通常与浏览器屏幕刷新次数相匹配**的特性，导致在高刷新率屏幕上滚动速率过快。
- 通过关联滚动速率和刷新率使得在不同分辨率设备上获得相对一致的滚动到顶部的体验。
4. 添加jsdelivr镜像站选项，来加速静态资源加载。~~我这里基本不能正常访问jsdelivr了~~