### PR TITLE
插件化mathjax，更换jsdelivr CDN，修复image tag bug，添加clipboard.js加载条件

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -72,7 +72,7 @@ mathjax:
   inlineMathMark: [['\\(', '\\)'],] #内联公式标记, e.g. [['\\(', '\\)'],['$', '$']]
 
 # polyfill 提供旧版本浏览器对新语法的支持
-# website: https://polyfill.io/v3/ 
+# website: https://cdnjs.cloudflare.com/polyfill
 polyfill:
   enable: false
 

--- a/layout/_partial/footer-script.ejs
+++ b/layout/_partial/footer-script.ejs
@@ -1,11 +1,16 @@
-<!-- aplayer -->
 <% if (page.aplayer) { %>
+<!-- aplayer -->
 <%- partial('../plug-in/aplayer') %>
 <% } %>
 
-<!-- dplayer -->
 <% if (page.dplayer) { %>
+<!-- dplayer -->
 <%- partial('../plug-in/dplayer') %>
+<% } %>
+
+<% if (theme.mathjax.enable && page.mathjax) { %> 
+<!-- mathjax -->
+<%- partial('../plug-in/mathjax') %>
 <% } %>
 
 <!-- copy button  -->

--- a/layout/_partial/footer-script.ejs
+++ b/layout/_partial/footer-script.ejs
@@ -13,8 +13,10 @@
 <%- partial('../plug-in/mathjax') %>
 <% } %>
 
+<% if (is_post() || is_page()) { %>
 <!-- copy button  -->
 <%- partial('../plug-in/clipboard') %>
+<% } %>
 
 
 <%# Gaug.es Analytics %>

--- a/layout/_partial/footer-script.ejs
+++ b/layout/_partial/footer-script.ejs
@@ -8,7 +8,7 @@
 <%- partial('../plug-in/dplayer') %>
 <% } %>
 
-<% if (theme.mathjax.enable && page.mathjax) { %> 
+<% if (page.mathjax) { %> 
 <!-- mathjax -->
 <%- partial('../plug-in/mathjax') %>
 <% } %>

--- a/layout/_widget/comment.ejs
+++ b/layout/_widget/comment.ejs
@@ -14,8 +14,8 @@
     <div class="valine-container comments-container content-padding--primary soft-size--large soft-style--box">
       <div id="valine_thread" class="valine-thread"></div>
     </div>
-    <script type="text/javascript" src="//unpkg.com/leancloud-storage@3.15.0/dist/av-min.js"></script>
-    <script type="text/javascript" src='//unpkg.com/valine/dist/Valine.min.js'></script>
+    <script type="text/javascript" src="https://<%= theme.jsdelivr_mirror || 'cdn.jsdelivr.net' %>/npm/leancloud-storage@3.15.0/dist/av-min.min.js"></script>
+    <script type="text/javascript" src="https://<%= theme.jsdelivr_mirror || 'cdn.jsdelivr.net' %>/npm/valine/dist/Valine.min.js"></script>
     <script type="text/javascript">
       new Valine({
         el: "#valine_thread",

--- a/layout/layout.ejs
+++ b/layout/layout.ejs
@@ -49,7 +49,7 @@
   <% } %>
 
   <% if (theme.polyfill.enable) { %>
-    <script src="https://polyfill.io/v3/polyfill.min.js?features=es6"></script>
+    <script src="https://cdnjs.cloudflare.com/polyfill/v3/polyfill.min.js?features=es6"></script>
   <% } %>
 
   <% if (config.highlight.enable) { %>

--- a/layout/layout.ejs
+++ b/layout/layout.ejs
@@ -48,23 +48,8 @@
     <%- favicon_tag(theme.favicon) %>
   <% } %>
 
-  <!--mathjax latex数学公式显示支持-->
   <% if (theme.polyfill.enable) { %>
     <script src="https://polyfill.io/v3/polyfill.min.js?features=es6"></script>
-  <% } %>
-  <% if (theme.mathjax.enable && page.mathjax) { %> 
-  <script>
-MathJax = {
-  tex: {
-    inlineMath: 
-	[<% theme.mathjax.inlineMathMark.forEach((pair) =>{ %>
-		['<%= pair[0] %>','<%= pair[1] %>'],
-    <% }) %>]
-  }
-};
-</script>
-
-    <script id="MathJax-script" async src="https://<%= theme.jsdelivr_mirror || 'cdn.jsdelivr.net' %>/npm/mathjax@3/es5/tex-mml-chtml.js"></script>
   <% } %>
 
   <% if (config.highlight.enable) { %>

--- a/layout/plug-in/aplayer.ejs
+++ b/layout/plug-in/aplayer.ejs
@@ -1,7 +1,7 @@
 <% if (theme.aplayer.enable) { %>
   <!-- aplayer 音频 start -->
-  <link rel="stylesheet" href="https://unpkg.com/aplayer@1.10.1/dist/APlayer.min.css">
-  <script type="text/javascript" src="https://unpkg.com/aplayer@1.10.1/dist/APlayer.min.js"></script>
+  <script src="https://<%= theme.jsdelivr_mirror || 'cdn.jsdelivr.net' %>/npm/aplayer@1.10.1/dist/APlayer.min.js"></script>
+  <link rel="stylesheet" href="https://<%= theme.jsdelivr_mirror || 'cdn.jsdelivr.net' %>/npm/aplayer@1.10.1/dist/APlayer.min.css">
   <script type="text/javascript">
     const aplayer = document.querySelectorAll(".aplayer-box");
     aplayer && initaplayer(aplayer);

--- a/layout/plug-in/dplayer.ejs
+++ b/layout/plug-in/dplayer.ejs
@@ -1,7 +1,7 @@
 <% if (theme.dplayer.enable) { %>
 <!-- dplayer 视频 start -->
-<script type="text/javascript" src="https://unpkg.com/hls.js@1.4.8/dist/hls.js"></script>
-<script type="text/javascript" src="https://unpkg.com/dplayer@1.27.1/dist/DPlayer.min.js"></script>
+<script type="text/javascript" src="https://<%= theme.jsdelivr_mirror || 'cdn.jsdelivr.net' %>/npm/hls.js"></script>
+<script type="text/javascript" src="https://<%= theme.jsdelivr_mirror || 'cdn.jsdelivr.net' %>/npm/dplayer@1.27.1/dist/DPlayer.min.js"></script>
 <script type="text/javascript">
   const dplayer = document.querySelectorAll(".dplayer-box");
   dplayer && initDPlayer(dplayer);

--- a/layout/plug-in/mathjax.ejs
+++ b/layout/plug-in/mathjax.ejs
@@ -1,3 +1,5 @@
+<% if (theme.mathjax.enable) { %>
+
 <script>
 MathJax = {
     tex: {
@@ -11,3 +13,5 @@ MathJax = {
 };
 </script>
 <script id="MathJax-script" async src="https://<%= theme.jsdelivr_mirror || 'cdn.jsdelivr.net' %>/npm/mathjax@3/es5/tex-mml-chtml.js"></script>
+
+<% } %>

--- a/layout/plug-in/mathjax.ejs
+++ b/layout/plug-in/mathjax.ejs
@@ -1,0 +1,13 @@
+<script>
+MathJax = {
+    tex: {
+    inlineMath: 
+    [
+    <% theme.mathjax.inlineMathMark.forEach((pair) =>{ %>
+        ['<%= pair[0] %>','<%= pair[1] %>'],
+    <% }) %>
+    ]
+    }
+};
+</script>
+<script id="MathJax-script" async src="https://<%= theme.jsdelivr_mirror || 'cdn.jsdelivr.net' %>/npm/mathjax@3/es5/tex-mml-chtml.js"></script>

--- a/scripts/index.js
+++ b/scripts/index.js
@@ -24,11 +24,12 @@ const buildDatasObj = (args, defaultObj = {}) => {
 
   if (args.length > 0) {
     args.forEach(item => {
-      let kv = item.split("=");
-      params[kv[0]] = kv[1];
+      let sepIdx = item.indexOf("=");
+      if(sepIdx == -1) return;
+      let k = item.slice(0,sepIdx)
+      params[k] = item.slice(sepIdx+1)
     });
   }
-
   return Object.assign({}, defaultObj, params);
 }
 


### PR DESCRIPTION
- 将mathjax封装为一个插件
- 将unkpg CDN URL更换为jsdelivr CDN URL（主要为aplayer，dplayer和leancloud评论相关），允许使用jsdelivr镜像统一反代
- 修复image tag 的BUG
```
{%  image
    url="https://example.com/A.jpg?A=1&B=2"
    title="title"
%}
```
如果url中存在参数，或者`=`，会导致生成的对象中的url值不完整，导致生成的页面引用了一个错误的资源，例如本例中错误生成的其引用的图片的url是`https://example.com/A.jpg?A`
- 添加clipboard.js加载条件，以加速非文章页面加载速度
- polyfill换源到cloudflare cdnjs