### PR TITLE
列表格式的归档页面

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -1,6 +1,7 @@
 # Header
 menu:
   首页: /
+  归档: /archives
   友链: /links
   关于: /about
 

--- a/layout/_partial/archive-article-list.ejs
+++ b/layout/_partial/archive-article-list.ejs
@@ -1,0 +1,37 @@
+<!-- post list container -->
+
+<%
+  let sorted_posts = site.posts.sort('date').reverse(); //from new to old
+  let years = []
+  let posts_by_year = sorted_posts.reduce((acc,p) => {
+    let y = p.date.format('YYYY')
+    if (acc[y]) acc[y].push(p)
+    else {
+      acc[y] = [p]
+      years.push(y)
+    }
+    return acc
+  },{})
+%>
+
+<div class="body-container">
+  <article class="content-container layout-block post-container">
+  <div class="article-info">
+    <% for(const y of years){ %>
+        <%- partial("../_widget/archive-year-card", { year: y, posts: posts_by_year[y] }) %>
+    <% } %>
+  </div>
+  <div class="widget-info">
+    <%- partial("../_widget/widget-author") %>
+
+    <%- partial("../_widget/widget-notice") %>
+
+    <%- partial("../_widget/widget-categories") %>
+
+    <%- partial("../_widget/widget-tags") %>
+  </div>
+</article>
+
+</div>
+
+

--- a/layout/_widget/archive-year-card.ejs
+++ b/layout/_widget/archive-year-card.ejs
@@ -1,0 +1,21 @@
+<!-- archive card -->
+<div class="markdown-body layout-margin content-padding--large soft-size--large soft-style--box">
+  <h1><%= year %></h1>  
+  <% posts.forEach(function(post, i) { %>
+      <div>
+        <span>
+          <%- partial("../_widget/date", { class_name: 'article-date', post: post, date_format: null }) %>
+        </span>
+          <% if (post.link) { %>
+            <a href="<%- url_for(post.link) %>" itemprop="url" target="_blank">
+              <h2><%= post.title || "(no title)" %></h2>
+            </a>
+          <% } else { %>
+            <a href="<%- url_for(post.path) %>" itemprop="url">
+              <strong><%= post.title || "(no title)" %></strong>
+            </a>
+          <% } %>
+
+      </div>
+  <% }) %>
+</div>

--- a/layout/archive.ejs
+++ b/layout/archive.ejs
@@ -1,5 +1,4 @@
 <!-- 归档 -->
 
-<%- partial('_partial/article-list') %>
+<%- partial('_partial/archive-article-list') %>
 
-<%- partial('_partial/pagination') %>


### PR DESCRIPTION
原有的归档页面和主页格式基本差不多，没有很好地展示所有文档，所以实现了一个文章列表格式的归档页面。
预览：
<img width="1252" alt="屏幕截图 2024-08-03 130310" src="https://github.com/user-attachments/assets/feb8a42f-e3c2-45e4-9399-54bc3659f049">

关联issue
[issue#44](https://github.com/miiiku/hexo-theme-flexblock/issues/44) <--但是似乎没有解决他的需求，毕竟既不支持展开和收缩，也不是系列文章，只是一个简单的日期归档
[issue#78](https://github.com/miiiku/hexo-theme-flexblock/issues/78)